### PR TITLE
show-event-details attribute was being ignored in Month view

### DIFF
--- a/templates/rcalendar/month.html
+++ b/templates/rcalendar/month.html
@@ -218,7 +218,7 @@
             </table>
         </ion-slide>
     </ion-slide-box>
-    <ion-content class="event-detail-container" has-bouncing="false">
+    <ion-content class="event-detail-container" has-bouncing="false" ng-if="showEventDetail">
         <table class="table table-bordered table-striped table-fixed event-detail-table">
             <tr ng-repeat="event in selectedDate.events" ng-click="eventSelected({event:event})">
                 <td ng-if="!event.allDay" class="monthview-eventdetail-timecolumn">{{::event.startTime|date: 'HH:mm'}}
@@ -234,4 +234,3 @@
         </table>
     </ion-content>
 </div>
-


### PR DESCRIPTION
Although the show-event-details attribute was visible to the Controller, the Month view template didn't do anything. Added an ng-show condition on showEventDetails. Seems to work now.

I've also added a section on the title-changed attribute to the README since this wasn't mentioned despite being used in the demo (and it's quite useful).